### PR TITLE
[hyperdrive-wasm] Update to hyperdrive v0.4.0

### DIFF
--- a/.github/workflows/build_wasm.yml
+++ b/.github/workflows/build_wasm.yml
@@ -49,7 +49,7 @@ jobs:
         uses: actions/checkout@master
         with:
           repository: delvtech/hyperdrive
-          ref: 'v0.3.0'
+          ref: 'v0.4.0'
           path: './hyperdrive'
           ssh-key: ${{ secrets.HYPERDRIVE_ACCESS_KEY }}
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1543,7 +1543,7 @@ dependencies = [
 
 [[package]]
 name = "hyperdrive-wasm"
-version = "0.2.0"
+version = "0.4.0"
 dependencies = [
  "console_error_panic_hook",
  "const-hex",

--- a/crates/hyperdrive-wasm/Cargo.toml
+++ b/crates/hyperdrive-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hyperdrive-wasm"
-version = "0.2.0"
+version = "0.4.0"
 edition = "2021"
 
 [lib]

--- a/crates/hyperdrive-wasm/example/index.js
+++ b/crates/hyperdrive-wasm/example/index.js
@@ -5,19 +5,20 @@ const ZERO_ADDRESS = '0x'.padEnd(42, '0');
 
 // const MAX_BUDGET = BigInt(MAX_U256).toString();
 const mockPoolInfo = {
-  shareReserves: '50000000000000000000000',
-  bondReserves: '151005848028396475250000',
-  sharePrice: '1001342906360984271',
-  longsOutstanding: '0',
-  shortsOutstanding: '0',
-  longExposure: '26169526102456856203830',
+  shareReserves: '10000000000000000000000000',
   shareAdjustment: '0',
+  zombieShareReserves: '0',
+  bondReserves: '10217899519533796120000000',
+  lpTotalSupply: '9999990000000000000000000',
+  sharePrice: '1000000000000000000',
+  longsOutstanding: '0',
   longAverageMaturityTime: '0',
+  shortsOutstanding: '0',
   shortAverageMaturityTime: '0',
-  lpTotalSupply: '49999999000000000000000',
-  lpSharePrice: '1001342906360984270',
-  withdrawalSharesProceeds: '0',
   withdrawalSharesReadyToWithdraw: '0',
+  withdrawalSharesProceeds: '0',
+  lpSharePrice: '1000000000000000000',
+  longExposure: '0',
 };
 const mockPoolConfig = {
   baseToken: ZERO_ADDRESS,
@@ -26,26 +27,32 @@ const mockPoolConfig = {
   fees: {
     curve: '100000000000000000',
     flat: '500000000000000',
-    governance: '150000000000000000',
+    governanceLP: '10000000000000000',
+    governanceZombie: '100000000000000000',
   },
   initialSharePrice: '1000000000000000000',
-  minimumShareReserves: '1000000000000000',
-  minimumTransactionAmount: '1000000000000',
-  timeStretch: '31124187940342208',
-  positionDuration: '31536000',
-  checkpointDuration: '86400',
-  linkerCodeHash: '0x2b287bf09de636779ceb93a28afed387376a9bdabfcf1470369558a3dc67accc',
+  minimumShareReserves: '10000000000000000000',
+  minimumTransactionAmount: '1000000000000000',
+  timeStretch: '44463125629060298',
+  positionDuration: '604800',
+  checkpointDuration: '3600',
+  linkerCodeHash: '0x'.padEnd(66, '0'),
   linkerFactory: ZERO_ADDRESS,
-  precisionThreshold: .5e18.toString(),
 };
 
 async function main() {
   hyperdriveWasm.initSync(hyperdriveWasm.wasmBuffer);
 
+  const spotRate = hyperdriveWasm.getSpotRate(mockPoolInfo, mockPoolConfig);
+  console.log('spotRate:', spotRate);
+
+  const spotPrice = hyperdriveWasm.getSpotPrice(mockPoolInfo, mockPoolConfig);
+  console.log('spotPrice:', spotPrice);
+
   const baseAmountRequired = hyperdriveWasm.calcOpenShort(
     mockPoolInfo,
     mockPoolConfig,
-    10e18.toString(),
+    (10e18).toString()
   );
   console.log('baseAmountRequired:', baseAmountRequired);
 }

--- a/crates/hyperdrive-wasm/example/package-lock.json
+++ b/crates/hyperdrive-wasm/example/package-lock.json
@@ -8,7 +8,7 @@
       "name": "hyperdrive-wasm-example",
       "version": "0.0.0",
       "dependencies": {
-        "@delvtech/hyperdrive-wasm": "file:delvtech-hyperdrive-wasm-0.1.0.tgz"
+        "@delvtech/hyperdrive-wasm": "file:delvtech-hyperdrive-wasm-0.2.0.tgz"
       },
       "bin": {
         "create-wasm-app": ".bin/create-wasm-app.js"
@@ -22,9 +22,9 @@
       }
     },
     "node_modules/@delvtech/hyperdrive-wasm": {
-      "version": "0.1.0",
-      "resolved": "file:delvtech-hyperdrive-wasm-0.1.0.tgz",
-      "integrity": "sha512-a6TtakbhyHqyy5SXxQkOVtpRv/If1Ch2dqNf6tqCo4BJSmdLRrG2AIGRoa+eOgG3pdWmzArNOJUkb1kC6zmJbw=="
+      "version": "0.2.0",
+      "resolved": "file:delvtech-hyperdrive-wasm-0.2.0.tgz",
+      "integrity": "sha512-2He7tOBY7pKCJOQp8wp/DALs5B9cn1qvP1zf1eRpRNlk2JeOiSR8Bt052IxJAYR9jgcuP+5Yd5qx7DbgJWWVqg=="
     },
     "node_modules/@discoveryjs/json-ext": {
       "version": "0.5.7",

--- a/crates/hyperdrive-wasm/example/package-lock.json
+++ b/crates/hyperdrive-wasm/example/package-lock.json
@@ -8,7 +8,7 @@
       "name": "hyperdrive-wasm-example",
       "version": "0.0.0",
       "dependencies": {
-        "@delvtech/hyperdrive-wasm": "file:delvtech-hyperdrive-wasm-0.2.0.tgz"
+        "@delvtech/hyperdrive-wasm": "file:delvtech-hyperdrive-wasm-0.4.0.tgz"
       },
       "bin": {
         "create-wasm-app": ".bin/create-wasm-app.js"
@@ -22,9 +22,9 @@
       }
     },
     "node_modules/@delvtech/hyperdrive-wasm": {
-      "version": "0.2.0",
-      "resolved": "file:delvtech-hyperdrive-wasm-0.2.0.tgz",
-      "integrity": "sha512-2He7tOBY7pKCJOQp8wp/DALs5B9cn1qvP1zf1eRpRNlk2JeOiSR8Bt052IxJAYR9jgcuP+5Yd5qx7DbgJWWVqg=="
+      "version": "0.4.0",
+      "resolved": "file:delvtech-hyperdrive-wasm-0.4.0.tgz",
+      "integrity": "sha512-Mc9IGQmFTyWaCgQjTHUuKyOJdCbajsRCNaSP8U7P0kSwETYKNqpTk+dDEL44OT/92mfKgUqwom97326oBwZF6w=="
     },
     "node_modules/@discoveryjs/json-ext": {
       "version": "0.5.7",

--- a/crates/hyperdrive-wasm/example/package.json
+++ b/crates/hyperdrive-wasm/example/package.json
@@ -17,6 +17,6 @@
     "webpack-dev-server": "^4.15.1"
   },
   "dependencies": {
-    "@delvtech/hyperdrive-wasm": "file:delvtech-hyperdrive-wasm-0.1.0.tgz"
+    "@delvtech/hyperdrive-wasm": "file:delvtech-hyperdrive-wasm-0.2.0.tgz"
   }
 }

--- a/crates/hyperdrive-wasm/example/package.json
+++ b/crates/hyperdrive-wasm/example/package.json
@@ -17,6 +17,6 @@
     "webpack-dev-server": "^4.15.1"
   },
   "dependencies": {
-    "@delvtech/hyperdrive-wasm": "file:delvtech-hyperdrive-wasm-0.2.0.tgz"
+    "@delvtech/hyperdrive-wasm": "file:delvtech-hyperdrive-wasm-0.4.0.tgz"
   }
 }

--- a/crates/hyperdrive-wasm/src/lib.rs
+++ b/crates/hyperdrive-wasm/src/lib.rs
@@ -125,8 +125,7 @@ pub fn getMaxShort(
         .to_string()
 }
 
-/// Gets the number of bonds received when opening a long for a given base
-/// amount.
+/// Gets the long amount that will be opened for a given base amount.
 ///
 /// @param poolInfo - The current state of the pool
 ///
@@ -142,11 +141,10 @@ pub fn calcOpenLong(poolInfo: &PoolInfo, poolConfig: &PoolConfig, baseAmount: St
     });
     let base_amount: FixedPoint = FixedPoint::from(U256::from_dec_str(&baseAmount).unwrap());
 
-    _state.get_long_amount(base_amount).to_string()
+    _state.calculate_open_long(base_amount).to_string()
 }
 
-/// Gets the amount of base the trader will need to deposit for a short of
-/// a given number of bonds.
+/// Gets the amount of base the trader will need to deposit for a short of a given size.
 ///
 /// @param poolInfo - The current state of the pool
 ///
@@ -165,13 +163,12 @@ pub fn calcOpenShort(poolInfo: &PoolInfo, poolConfig: &PoolConfig, shortAmount: 
     let spot_price = _state.get_spot_price();
 
     _state
-        .get_short_deposit(short_amount, spot_price, fixed!(0))
+        .calculate_open_short(short_amount, spot_price, fixed!(0))
         .unwrap()
         .to_string()
 }
 
-/// Get the max amount of base tokens that can be spent on a long position
-/// given the current state of the pool.
+/// Gets the max long that can be opened given a budget.
 ///
 /// @param poolInfo - The current state of the pool
 ///
@@ -208,7 +205,7 @@ pub fn getMaxLong(
         .to_string()
 }
 
-/// Get the price of a single long token given the current state of the pool.
+/// Gets the pool's spot price, i.e. the price to open a long of 1.
 ///
 /// @param poolInfo - The current state of the pool
 ///
@@ -237,61 +234,6 @@ pub fn getSpotRate(poolInfo: &PoolInfo, poolConfig: &PoolConfig) -> String {
         config: serde_wasm_bindgen::from_value(poolConfig.into()).unwrap(),
     });
     _state.get_spot_rate().to_string()
-}
-
-/// Gets the long amount that will be opened for a given base amount.
-///
-/// @param poolInfo - The current state of the pool
-///
-/// @param poolConfig - The pool's configuration
-///
-/// @param baseAmount - The amount of base tokens to open a long for
-#[wasm_bindgen(skip_jsdoc)]
-pub fn getLongAmount(poolInfo: &PoolInfo, poolConfig: &PoolConfig, baseAmount: String) -> String {
-    utils::set_panic_hook();
-    let _state = State::from(&WasmState {
-        info: serde_wasm_bindgen::from_value(poolInfo.into()).unwrap(),
-        config: serde_wasm_bindgen::from_value(poolConfig.into()).unwrap(),
-    });
-
-    _state
-        .get_long_amount(U256::from_dec_str(&baseAmount).unwrap())
-        .to_string()
-}
-
-/// Gets the amount of base the trader will need to deposit for a short of a
-/// given size.
-///
-/// @param poolInfo - The current state of the pool
-///
-/// @param poolConfig - The pool's configuration
-///
-/// @param shortAmount - The amount of longs to short
-///
-/// @param openSharePrice - The open share price of the pool's current
-/// checkpoint
-#[wasm_bindgen(skip_jsdoc)]
-pub fn getShortDeposit(
-    poolInfo: &PoolInfo,
-    poolConfig: &PoolConfig,
-    shortAmount: String,
-    spotPrice: String,
-    openSharePrice: String,
-) -> String {
-    utils::set_panic_hook();
-    let _state = State::from(&WasmState {
-        info: serde_wasm_bindgen::from_value(poolInfo.into()).unwrap(),
-        config: serde_wasm_bindgen::from_value(poolConfig.into()).unwrap(),
-    });
-
-    _state
-        .get_short_deposit(
-            FixedPoint::from(U256::from_dec_str(&shortAmount).unwrap()),
-            FixedPoint::from(I256::from_raw(U256::from_dec_str(&spotPrice).unwrap())),
-            FixedPoint::from(I256::from_raw(U256::from_dec_str(&openSharePrice).unwrap())),
-        )
-        .unwrap()
-        .to_string()
 }
 
 #[derive(Serialize, Deserialize)]

--- a/crates/hyperdrive-wasm/src/lib.rs
+++ b/crates/hyperdrive-wasm/src/lib.rs
@@ -18,7 +18,8 @@ const FEES: &'static str = r#"
 interface Fees {
     curve: string;
     flat: string;
-    governance: string;
+    governanceLP: string;
+    governanceZombie: string;
 }"#;
 
 #[wasm_bindgen(typescript_custom_section)]
@@ -36,7 +37,6 @@ interface PoolConfig {
     fees: Fees,
     linkerFactory: string,
     linkerCodeHash: string,
-    precisionThreshold: string,
 }"#;
 
 #[wasm_bindgen(typescript_custom_section)]
@@ -55,6 +55,7 @@ interface PoolInfo {
     withdrawalSharesProceeds: string,
     lpSharePrice: string,
     longExposure: string,
+    zombieShareReserves: string,
 }
 "#;
 
@@ -297,7 +298,8 @@ pub fn getShortDeposit(
 pub struct WasmFees {
     pub curve: String,
     pub flat: String,
-    pub governance: String,
+    pub governanceLP: String,
+    pub governanceZombie: String,
 }
 
 #[derive(Serialize, Deserialize)]
@@ -314,7 +316,6 @@ pub struct WasmPoolConfig {
     pub fees: WasmFees,
     pub linkerFactory: String,
     pub linkerCodeHash: String,
-    pub precisionThreshold: String,
 }
 
 #[derive(Serialize, Deserialize)]
@@ -332,6 +333,7 @@ pub struct WasmPoolInfo {
     pub withdrawalSharesProceeds: String,
     pub lpSharePrice: String,
     pub longExposure: String,
+    pub zombieShareReserves: String,
 }
 
 #[derive(Serialize, Deserialize)]
@@ -350,7 +352,10 @@ impl From<&WasmState> for State {
                 fees: _Fees {
                     curve: U256::from_dec_str(&wasm_state.config.fees.curve).unwrap(),
                     flat: U256::from_dec_str(&wasm_state.config.fees.flat).unwrap(),
-                    governance: U256::from_dec_str(&wasm_state.config.fees.governance).unwrap(),
+                    governance_lp: U256::from_dec_str(&wasm_state.config.fees.governanceLP)
+                        .unwrap(),
+                    governance_zombie: U256::from_dec_str(&wasm_state.config.fees.governanceZombie)
+                        .unwrap(),
                 },
                 initial_share_price: U256::from_dec_str(&wasm_state.config.initialSharePrice)
                     .unwrap(),
@@ -368,8 +373,6 @@ impl From<&WasmState> for State {
                 linker_code_hash: hex::decode(&wasm_state.config.linkerCodeHash)
                     .unwrap()
                     .try_into()
-                    .unwrap(),
-                precision_threshold: U256::from_dec_str(&wasm_state.config.precisionThreshold)
                     .unwrap(),
             },
             info: _PoolInfo {
@@ -398,6 +401,8 @@ impl From<&WasmState> for State {
                     &wasm_state.info.withdrawalSharesReadyToWithdraw,
                 )
                 .unwrap(),
+                zombie_share_reserves: U256::from_dec_str(&wasm_state.info.zombieShareReserves)
+                    .unwrap(),
             },
         }
     }


### PR DESCRIPTION
Updates the hyperdrive-wasm crate to be compatible with hyperdrive v0.4.0. The version has been updated to match the hyperdrive version. It'll stay synced with hyperdrive moving forward.

TODO: Bump hyperdrive crate versions in new hyperdrive releases.