### PR TITLE
time stretch hotfix

### DIFF
--- a/.github/workflows/build_linux_wheel.yml
+++ b/.github/workflows/build_linux_wheel.yml
@@ -49,7 +49,7 @@ jobs:
         uses: actions/checkout@master
         with:
           repository: delvtech/hyperdrive
-          ref: "v0.5.0"
+          ref: "v0.5.1"
           path: "./hyperdrive"
           ssh-key: ${{ secrets.HYPERDRIVE_ACCESS_KEY }}
 

--- a/.github/workflows/build_wasm.yml
+++ b/.github/workflows/build_wasm.yml
@@ -38,7 +38,7 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: 16
-          registry-url: 'https://registry.npmjs.org'
+          registry-url: "https://registry.npmjs.org"
 
       - name: setup foundry
         uses: foundry-rs/foundry-toolchain@v1
@@ -49,8 +49,8 @@ jobs:
         uses: actions/checkout@master
         with:
           repository: delvtech/hyperdrive
-          ref: 'v0.5.0'
-          path: './hyperdrive'
+          ref: "v0.5.1"
+          path: "./hyperdrive"
           ssh-key: ${{ secrets.HYPERDRIVE_ACCESS_KEY }}
 
       - name: build hyperdrive-wasm

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -40,7 +40,7 @@ jobs:
         uses: actions/checkout@master
         with:
           repository: delvtech/hyperdrive
-          ref: "v0.5.0"
+          ref: "v0.5.1"
           path: "./hyperdrive"
           ssh-key: ${{ secrets.HYPERDRIVE_ACCESS_KEY }}
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -30,7 +30,7 @@ jobs:
         uses: actions/checkout@master
         with:
           repository: delvtech/hyperdrive
-          ref: "v0.5.0"
+          ref: "v0.5.1"
           path: "./hyperdrive"
           ssh-key: ${{ secrets.HYPERDRIVE_ACCESS_KEY }}
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,7 +30,7 @@ jobs:
         uses: actions/checkout@master
         with:
           repository: delvtech/hyperdrive
-          ref: "v0.5.0"
+          ref: "v0.5.1"
           path: "./hyperdrive"
           ssh-key: ${{ secrets.HYPERDRIVE_ACCESS_KEY }}
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1543,7 +1543,7 @@ dependencies = [
 
 [[package]]
 name = "hyperdrive-wasm"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "console_error_panic_hook",
  "const-hex",
@@ -1579,7 +1579,7 @@ dependencies = [
 
 [[package]]
 name = "hyperdrivepy"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "ethers",
  "eyre",

--- a/crates/hyperdrive-wasm/Cargo.toml
+++ b/crates/hyperdrive-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hyperdrive-wasm"
-version = "0.5.0"
+version = "0.5.1"
 edition = "2021"
 
 [lib]

--- a/crates/hyperdrive-wasm/example/package.json
+++ b/crates/hyperdrive-wasm/example/package.json
@@ -17,6 +17,6 @@
     "webpack-dev-server": "^4.15.1"
   },
   "dependencies": {
-    "@delvtech/hyperdrive-wasm": "file:delvtech-hyperdrive-wasm-0.5.0.tgz"
+    "@delvtech/hyperdrive-wasm": "file:delvtech-hyperdrive-wasm-0.5.1.tgz"
   }
 }

--- a/crates/hyperdrivepy/Cargo.toml
+++ b/crates/hyperdrivepy/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "hyperdrivepy"
 edition = "2021"
-version = "0.5.0"
+version = "0.5.1"
 authors = [
     "Dylan Paiton",
     "Matt Brown",

--- a/crates/hyperdrivepy/pyproject.toml
+++ b/crates/hyperdrivepy/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "hyperdrivepy"
-version = "0.5.0"
+version = "0.5.1"
 requires-python = ">=3.7"
 classifiers = [
   "Programming Language :: Rust",

--- a/crates/hyperdrivepy/python/hyperdrivepy/hyperdrive_utils.py
+++ b/crates/hyperdrivepy/python/hyperdrivepy/hyperdrive_utils.py
@@ -13,12 +13,14 @@ def get_time_stretch(rate: str, position_duration: str) -> str:
 
     Arguments
     ---------
-    rate : str (FixedPoint)
+    rate: str (FixedPoint)
         The pool's spot rate (aka apr, or fixed rate).
+    position_duration: str(FixedPoint)
+        The amount of time before a trade matures.
 
     Returns
     -------
-    time_stretch : str (FixedPoint)
+    time_stretch: str (FixedPoint)
         The time stretch parameter (tau).
     """
     return rust_module.get_time_stretch(rate, position_duration)
@@ -35,14 +37,14 @@ def get_effective_share_reserves(
 
     Arguments
     ---------
-    share_reserves : str (FixedPoint)
+    share_reserves: str (FixedPoint)
         The pool's share reserves.
-    share_adjustment : str (I256)
+    share_adjustment: str (I256)
         The zeta factor for adjusting share reserves.
 
     Returns
     -------
-    effective_share_reserves : str (FixedPoint)
+    effective_share_reserves: str (FixedPoint)
         The adjusted share reserves, accounting for the zeta factor.
     """
     return rust_module.get_effective_share_reserves(share_reserves, share_adjustment)
@@ -65,22 +67,22 @@ def calculate_initial_bond_reserves(
 
     Arguments
     ---------
-    effective_share_reserves : str (FixedPoint)
+    effective_share_reserves: str (FixedPoint)
         The pool's effective share reserves. The effective share
         reserves are a modified version of the share reserves
         used when pricing trades.
-    initial_share_price : str (FixedPoint)
+    initial_share_price: str (FixedPoint)
         The pool's initial share price.
-    apr : str (FixedPoint)
+    apr: str (FixedPoint)
         The pool's APR.
-    position_duration : str (FixedPoint)
+    position_duration: str (FixedPoint)
         The amount of time until maturity in seconds.
-    time_stretch : str (FixedPoint)
+    time_stretch: str (FixedPoint)
         The time stretch parameter (tau).
 
     Returns
     -------
-    bond_reserves : str (FixedPoint)
+    bond_reserves: str (FixedPoint)
         The bond reserves (without adjustment) that make
         the pool have a specified APR.
     """

--- a/crates/hyperdrivepy/setup.py
+++ b/crates/hyperdrivepy/setup.py
@@ -4,7 +4,7 @@ from setuptools_rust import Binding, RustExtension
 
 setup(
     name="hyperdrivepy",
-    version="0.5.0",
+    version="0.5.1",
     packages=["hyperdrivepy"],
     package_dir={"": "python"},
     rust_extensions=[

--- a/system_tests/wrapper_tests.py
+++ b/system_tests/wrapper_tests.py
@@ -89,7 +89,15 @@ def test_get_time_stretch():
     """test get_time_stretch."""
     time_stretch = hyperdrivepy.get_time_stretch(
         hyperdrivepy.get_spot_rate(POOL_CONFIG, POOL_INFO),
-        str(POOL_CONFIG.positionDuration),
+        str(60 * 60 * 24 * 365),  # 1 year
+    )
+    assert time_stretch is not None, "Failed to get time_stretch."
+    assert isinstance(time_stretch, str), "Expected time_stretch to be a string."
+    assert float(time_stretch) > 0, "Expected time_stretch to be > 0."
+
+    time_stretch = hyperdrivepy.get_time_stretch(
+        hyperdrivepy.get_spot_rate(POOL_CONFIG, POOL_INFO),
+        str(60 * 60 * 24 * 30),  # ~1 month
     )
     assert time_stretch is not None, "Failed to get time_stretch."
     assert isinstance(time_stretch, str), "Expected time_stretch to be a string."


### PR DESCRIPTION
The rust `get_time_stretch` formula was an incorrect port from solidity, and the test was not sufficiently complicated to catch it. These are resolved now, but the python wheels need to be rebuilt using Hyperdrive 0.5.1